### PR TITLE
Add helper function to improve encapsulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ You can create a router by mixing the routes and handlers together:
   server := httptest.NewServer(router)
 ```
 
+Handlers can obtain parameters derived from the URL path:
+```go
+  ownerId := rata.Param(request, "owner_id")
+```
+
 Meanwhile, on the client side, you can create a request generator:
 ```go
   requestGenerator := rata.NewRequestGenerator(server.URL, petRoutes)

--- a/docs.go
+++ b/docs.go
@@ -41,6 +41,10 @@ You can create a router by mixing the routes and handlers together:
 The router is just an http.Handler, so it can be used to create a server in the usual fashion:
   server := httptest.NewServer(router)
 
+The handlers can obtain parameters derived from the URL path:
+
+  ownerId := rata.Param(request, "owner_id")
+
 Meanwhile, on the client side, you can create a request generator:
   requestGenerator := rata.NewRequestGenerator(server.URL, petRoutes)
 

--- a/param.go
+++ b/param.go
@@ -1,0 +1,8 @@
+package rata
+
+import "net/http"
+
+//  Param returns the parameter with the given name from the given request.
+func Param(req *http.Request, paramName string) string {
+	return req.URL.Query().Get(":" + paramName)
+}


### PR DESCRIPTION
Rather than handlers needing to access parameters thus:

  req.URL.Query().Get(":neato")

they can now use a helper function:

  rata.Param(req, "neato")

which is more symmetric with the client-side and does not depend
on the implementation storing URL path parameters as query
parameters.
