### PR TITLE
adds CreateURL method, fixes param encoding of CreatePath

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // RequestGenerator creates http.Request objects with the correct path and method
@@ -41,16 +39,10 @@ func (r *RequestGenerator) CreateRequest(
 		return &http.Request{}, fmt.Errorf("No route exists with the name %s", name)
 	}
 
-	routePath, err := route.CreatePath(params)
+	u, err := route.CreateURL(r.host, params)
 	if err != nil {
 		return &http.Request{}, err
 	}
-
-	u, err := url.Parse(r.host)
-	if err != nil {
-		return &http.Request{}, err
-	}
-	u.Path = path.Join(u.Path, routePath)
 
 	req, err := http.NewRequest(route.Method, u.String(), body)
 	if err != nil {

--- a/requests_test.go
+++ b/requests_test.go
@@ -15,12 +15,14 @@ var _ = Describe("Requests", func() {
 	const (
 		PathWithSlash    = "WithSlash"
 		PathWithoutSlash = "WithoutSlash"
+		PathWithParams   = "WithParams"
 	)
 
 	JustBeforeEach(func() {
 		routes := Routes{
 			{Name: PathWithSlash, Method: "GET", Path: "/some-route"},
 			{Name: PathWithoutSlash, Method: "GET", Path: "some-route"},
+			{Name: PathWithParams, Method: "GET", Path: "/foo/:bar"},
 		}
 		requestGenerator = NewRequestGenerator(
 			host,
@@ -73,6 +75,39 @@ var _ = Describe("Requests", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(request.URL.String()).To(Equal("example.com/some-route"))
+				})
+			})
+		})
+
+		Context("when using params that can be interpreted as path segments", func() {
+			BeforeEach(func() {
+				host = "http://example.com"
+			})
+
+			Context("when the param has a slash", func() {
+				It("generates a URL with the slash encoded as %2F", func() {
+					request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something/with/slashes"}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(request.URL.String()).To(Equal("http://example.com/foo/something%2Fwith%2Fslashes"))
+				})
+			})
+
+			Context("when the param has a question mark", func() {
+				It("generates a URL with the question mark encoded as %3F", func() {
+					request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something?with?question?marks"}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(request.URL.String()).To(Equal("http://example.com/foo/something%3Fwith%3Fquestion%3Fmarks"))
+				})
+			})
+
+			Context("when the param has a pound sign", func() {
+				It("generates a URL with the pound sign encoded as %23", func() {
+					request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something#with#pound#signs"}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(request.URL.String()).To(Equal("http://example.com/foo/something%23with%23pound%23signs"))
 				})
 			})
 		})


### PR DESCRIPTION
We noticed that there are problems with the RequestGenerator when trying to substitute values with a "/" in them. In general, you should be able to include slashes, pound signs, question marks, and other [reserved characters](https://perishablepress.com/stop-using-unsafe-characters-in-urls/)

We also created a new method CreateURL. When the RequestGenerator used CreatePath, first CreatePath would encode params via `u.String()`, and then the path was parsed again and re-encoded when added to the host.

