### PR TITLE
support encoding path segments

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"path"
 )
 
 // RequestGenerator creates http.Request objects with the correct path and method
@@ -41,16 +39,10 @@ func (r *RequestGenerator) CreateRequest(
 		return &http.Request{}, fmt.Errorf("No route exists with the name %s", name)
 	}
 
-	routePath, err := route.CreatePath(params)
+	u, err := route.createURL(r.host, params)
 	if err != nil {
 		return &http.Request{}, err
 	}
-
-	u, err := url.Parse(r.host)
-	if err != nil {
-		return &http.Request{}, err
-	}
-	u.Path = path.Join(u.Path, routePath)
 
 	req, err := http.NewRequest(route.Method, u.String(), body)
 	if err != nil {

--- a/requests_test.go
+++ b/requests_test.go
@@ -15,12 +15,14 @@ var _ = Describe("Requests", func() {
 	const (
 		PathWithSlash    = "WithSlash"
 		PathWithoutSlash = "WithoutSlash"
+		PathWithParams   = "WithParams"
 	)
 
 	JustBeforeEach(func() {
 		routes := Routes{
 			{Name: PathWithSlash, Method: "GET", Path: "/some-route"},
 			{Name: PathWithoutSlash, Method: "GET", Path: "some-route"},
+			{Name: PathWithParams, Method: "GET", Path: "/foo/:bar"},
 		}
 		requestGenerator = NewRequestGenerator(
 			host,
@@ -73,6 +75,54 @@ var _ = Describe("Requests", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(request.URL.String()).To(Equal("example.com/some-route"))
+				})
+			})
+		})
+
+		Context("when using params that can be interpreted as path segments", func() {
+			Context("without a host", func() {
+				BeforeEach(func() {
+					host = ""
+				})
+
+				It("generates a URL with the slash encoded as %2F", func() {
+					request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something/with/slashes"}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(request.URL.String()).To(Equal("/foo/something%2Fwith%2Fslashes"))
+				})
+			})
+
+			Context("with a host", func() {
+				BeforeEach(func() {
+					host = "http://example.com/test"
+				})
+
+				Context("when the param has a slash", func() {
+					It("generates a URL with the slash encoded as %2F", func() {
+						request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something/with/slashes"}, nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(request.URL.String()).To(Equal("http://example.com/test/foo/something%2Fwith%2Fslashes"))
+					})
+				})
+
+				Context("when the param has a question mark", func() {
+					It("generates a URL with the question mark encoded as %3F", func() {
+						request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something?with?question?marks"}, nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(request.URL.String()).To(Equal("http://example.com/test/foo/something%3Fwith%3Fquestion%3Fmarks"))
+					})
+				})
+
+				Context("when the param has a pound sign", func() {
+					It("generates a URL with the pound sign encoded as %23", func() {
+						request, err := requestGenerator.CreateRequest(PathWithParams, Params{"bar": "something#with#pound#signs"}, nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(request.URL.String()).To(Equal("http://example.com/test/foo/something%23with%23pound%23signs"))
+					})
 				})
 			})
 		})

--- a/routes.go
+++ b/routes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"runtime"
 	"strings"
 )
@@ -89,6 +90,42 @@ func (r Route) CreatePath(params Params) (string, error) {
 		return "", err
 	}
 	return u.String(), nil
+}
+
+// CreateURL combines the route's path pattern with a Host
+// and a Params map to produce a valid URL.
+func (r Route) createURL(host string, params Params) (*url.URL, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+
+	path := path.Join(u.Path, r.Path)
+	components := strings.Split(path, "/")
+	rawComponents := make([]string, len(components))
+	copy(rawComponents, components)
+
+	for i, c := range components {
+		if len(c) == 0 {
+			continue
+		}
+
+		val := c
+		if c[0] == ':' {
+			var ok bool
+			val, ok = params[c[1:]]
+			if !ok {
+				return nil, fmt.Errorf("missing param %s", c)
+			}
+			components[i] = val
+			rawComponents[i] = url.PathEscape(val)
+		}
+	}
+
+	u.Path = strings.Join(components, "/")
+	u.RawPath = strings.Join(rawComponents, "/")
+
+	return u, nil
 }
 
 // Routes is a Route collection.


### PR DESCRIPTION
When there are path segments that contain characters that are not encoded correctly, bad things happen.

For example if you have a route `/:name` and `name`'s value contains a `/` the route never matches correctly.

This fixes that!